### PR TITLE
VDI.compose: rewrites the cached child information, refreshes tapdisk

### DIFF
--- a/vhdformat.ml
+++ b/vhdformat.ml
@@ -61,6 +61,16 @@ let activate dev file ty =
     Tapctl.unpause (ctx ()) dev file ty
   end
 
+let refresh dev : unit =
+  match Tapctl.of_device (ctx ()) dev with
+    | dev, driver, (Some ("vhd", file)) ->
+      t_pause dev;
+      t_unpause dev file Tapctl.Vhd
+    | dev, driver, (Some ("aio", file)) ->
+      t_pause dev;
+      t_unpause dev file Tapctl.Aio
+    | _,   _, _ -> () (* no active file, nothing to refresh *)
+
 let deactivate dev =
   let dev, _, _ = Tapctl.of_device (ctx ()) dev in
   Tapctl.close (ctx ()) dev


### PR DESCRIPTION
Refreshing tapdisk is required because the leaf is active
and will not have the correct data after a reparent.

Rewriting the cached child information is important to avoid
later problems with the GC

Signed-off-by: David Scott dave.scott@eu.citrix.com
