### PR TITLE
raw+file Datapath.detach resolves symlinks before consulting losetup

### DIFF
--- a/lib/losetup.py
+++ b/lib/losetup.py
@@ -19,6 +19,9 @@ class Loop:
 
 def find(dbg, path):
     """Return the active loop device associated with the given path"""
+    # The kernel loop driver will transparently follow symlinks, so
+    # we must too.
+    path = os.path.realpath(path)
     for line in call(dbg, ["losetup", "-a"]).split("\n"):
         line = line.strip()
         if line <> "":


### PR DESCRIPTION
The kernel loop driver transparently resolves symlinks, so we must
too.

Signed-off-by: David Scott <dave.scott@citrix.com>