### PR TITLE
raw+file Datapath.attach must handle filenames containing spaces

### DIFF
--- a/lib/losetup.py
+++ b/lib/losetup.py
@@ -27,7 +27,9 @@ def find(dbg, path):
         if line <> "":
             bits = line.split()
             loop = bits[0][0:-1]
-            this_path = bits[2][1:-1]
+            open_bracket = line.find('(')
+            close_bracket = line.find(')')
+            this_path = line[open_bracket+1:close_bracket]
             if this_path == path:
                 return Loop(path, loop)
     return None


### PR DESCRIPTION
The losetup module was failing to parse the output of `losetup -a`.
It now extracts the path by finding the substring within the ( brackets )
e.g.

/dev/loop3: [0035]:262 (/run/sr-mount/dev/disk/by-id/ata-WDC_WD2502ABYS-18B7A0_WD-WCAT1H334077-part3/Created by XenRT)

Signed-off-by: David Scott <dave.scott@citrix.com>